### PR TITLE
Remove redundant 'show' event

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,6 @@ Dialog.prototype.show = function(){
 
   this.el.appendTo('body');
   this.el.css({ marginLeft: -(this.el.width() / 2) + 'px' });
-  this.emit('show');
   return this;
 };
 


### PR DESCRIPTION
Dialog was emitting 2 'show' events during show method. One of them is
all that should be needed.
