### PR TITLE
Fix set margin left before offsetWidth prop is assigned

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,6 +223,7 @@ Dialog.prototype.escapable = function(){
 
 Dialog.prototype.show = function(){
   var overlay = this._overlay;
+  var self = this;
 
   // overlay
   if (overlay) {
@@ -235,7 +236,9 @@ Dialog.prototype.show = function(){
 
   // position
   document.body.appendChild(this.el);
-  this.el.style.marginLeft = -(this.el.offsetWidth / 2) + 'px'
+  setTimeout(function() {
+    self.el.style.marginLeft = -(self.el.offsetWidth / 2) + 'px'
+  }, 0);
 
   this._classes.remove('hide');
   this.emit('show');


### PR DESCRIPTION
There are times where `this.el.offsetWidth`'s value is `0` and the position gets centered wrong at [index.js#L238](https://github.com/component/dialog/blob/a56a5178dca1c95b6128ca76d63a1c3ff0ce145c/index.js#L238).

I set a timeout right after DOM append so `this.el.offsetWidth` retrieves the actual _offsetWidth_ value.
