### PR TITLE
dialog should start in "hide" state

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,10 +119,6 @@ Dialog.prototype.render = function(options){
     pEl.parentNode.insertBefore(msg.el || msg, pEl);
     pEl.parentNode.removeChild(pEl);
   }
-
-  setTimeout(function(){
-    self._classes.remove('hide');
-  }, 0);
 };
 
 /**


### PR DESCRIPTION
If you created the dialog but show()ed it some time later, the effect
would not play. Only on subsequent hide() + show().

Some feedback would be nice, otherwise I will merge this in a few days.
