### PR TITLE
fix traversing to '#' on close

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,10 +98,10 @@ Dialog.prototype.render = function(options){
     , pEl = query('p', el)
     , msg = options.message;
 
-  events.bind(query('.close', el), 'click', function () {
+  events.bind(query('.close', el), 'click', function (ev) {
+    ev.preventDefault();
     self.emit('close');
     self.hide();
-    return false;
   });
 
   if (titleEl) {


### PR DESCRIPTION
since we don't use jQuery any more returning `false` from event handler
does not supress default browser behavior
added call to `preventDefault` in close handler
