### PR TITLE
add Dialog.fixed function

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -62,6 +62,11 @@ $ npm install dialog-component
 
   Add a non-clickable overlay making it modal.
 
+### Dialog#fixed()
+
+  Dialogs are centered by default. If you'd rather use CSS to position the dialog make it `fixed`;
+  no per element CSS properties are added to such dialogs.
+
 ### Dialog#escapable()
 
   This is __private__ as it is implied by other options.

--- a/index.js
+++ b/index.js
@@ -209,6 +209,18 @@ Dialog.prototype.escapable = function(){
 };
 
 /**
+ * Fixed dialogs position can be manipulated through CSS.
+ *
+ * @return {Dialog} for chaining
+ * @api public
+ */
+
+Dialog.prototype.fixed = function(){
+  this._fixed = true;
+  return this;
+}
+
+/**
  * Show the dialog.
  *
  * Emits "show" event.
@@ -231,7 +243,9 @@ Dialog.prototype.show = function(){
 
   // position
   document.body.appendChild(this.el);
-  this.el.style.marginLeft = -(this.el.offsetWidth / 2) + 'px'
+  if (!this._fixed) {
+    this.el.style.marginLeft = -(this.el.offsetWidth / 2) + 'px'
+  }
 
   this._classes.remove('hide');
   this.emit('show');

--- a/test/index.html
+++ b/test/index.html
@@ -4,6 +4,12 @@
     <title>Dialog</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <link rel="stylesheet" href="../build/build.css" />
+    <style>
+      #dialog.off-center {
+        top: 20px;
+        left: 15%;
+      }
+    </style>
   </head>
   <body>
     <title>Dialog</title>
@@ -64,6 +70,17 @@
                   .show()
                   .on('hide', function(){
                     console.log('closed seventh');
+
+                    dialog('This one is not centered')
+                    .effect('fade')
+                    .closable()
+                    .fixed()
+                    .addClass('off-center')
+                    .show()
+                    .on('hide', function(){
+                      console.log('closed eight');
+                    });
+
                   });
                 });
               });


### PR DESCRIPTION
it allows for displaying dialogs that are not centered

Default method of centering the dialog relies on modifying element `margin-left` - it makes it hard to position the dialog using CSS (for example: to display without the margin on the narrow page etc.) 
This change lets people to declare the dialog as `fixed` in which case we stay away from element style and let application CSS to take over.

It also makes merging component/dialog#13 less disruptive (as things stand today one can undo style modifications, if we do it in async way though all bets are off)
