### PR TITLE
added wrap method for added wrapping block with overflow: auto 

### DIFF
--- a/dialog.css
+++ b/dialog.css
@@ -91,3 +91,25 @@
   text-align: left;
   width: inherit;
 }
+
+/* dialog wrap */
+
+.dialog-wrap {
+  position: fixed;
+  z-index: 1000;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
+.dialog-wrap.not-modal {
+  cursor: pointer;
+}
+
+.dialog-wrap .dialog {
+  position: absolute;
+  margin-bottom: 150px;
+  cursor: auto;
+}

--- a/index.js
+++ b/index.js
@@ -224,6 +224,45 @@ Dialog.prototype.fixed = function(){
 }
 
 /**
+ * Wraps the dialog el with .dialog-wrap element. 
+ * Useful for nice scrollbar feature in large dialogs.
+ * Can be used with overlay only (otherwise it will generate overlay by itself)!
+ *
+ * @return {Dialog} for chaining
+ * @api public
+ */
+
+Dialog.prototype.wrap = function(){
+  var self = this;
+  var wrap = document.createElement('div');
+  wrap.className = 'dialog-wrap';
+
+  //if no overlay add it
+  if (!self._overlay) {
+    self._overlay  = overlay();
+  }
+
+  //as wrap covers all screen it should take care of close on overlay zone click (if not modal)
+  if (!self._classes.has('modal')) {
+    wrap.className += ' not-modal'
+    events.bind(wrap, 'click', function(e) {
+      if (e.target === wrap) {
+        self.emit('close');
+        self.hide();
+      }
+    });
+  }
+
+  //append dialog
+  wrap.appendChild(self.el);
+
+  //redefine this.el so methods like remove can clean up full wrap instead of the element
+  self.el = wrap;
+
+  return this;
+}
+
+/**
  * Show the dialog.
  *
  * Emits "show" event.

--- a/test/index.html
+++ b/test/index.html
@@ -23,6 +23,9 @@
         top: 20px;
         left: 15%;
       }
+      .dialog.pretty-high .content {
+        min-height: 1000px;
+      }
     </style>
   </head>
   <body>
@@ -94,6 +97,18 @@
                     .on('hide', function(){
                       console.log('closed eight');
                     });
+
+                      dialog('Pretty high wrapped dialog')
+                      .effect('fade')
+                      .overlay()
+                      .closable()
+                      .fixed()
+                      .wrap()
+                      .addClass('pretty-high')
+                      .show()
+                      .on('hide', function(){
+                        console.log('closed nine');
+                      });
 
                   });
                 });


### PR DESCRIPTION
useful for high big height dialogs
the code looks a bit tricky but it's really cross-browser, and it's difficult to add this feature without changing the code a lot (or maybe rewrite it to add a wrap always? it'll do the styling options more flexible).
last example added uses that feature.
it the pull request is merged, docs have to be updated.