### PR TITLE
Allow loading of custom template from constructor options

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,10 @@ function dialog(title, msg){
 function Dialog(options) {
   Emitter.call(this);
   options = options || {};
-  this.template = require('./template.html');
+  if (!options.template) {
+    options.template = require('./template.html');
+  }
+  this.template = options.template;
   this.el = domify(this.template);
   this._classes = classes(this.el);
   this.render(options);


### PR DESCRIPTION
Hello,

It's possible I'm completely misunderstanding how one should be using this component, but I'm not seeing how you would introduce your own custom template into this module without pulling your own copy and modifying it.  I'm requiring the component from DuoJS and I'd like to not have to modify it in order to fit my need.  Therefore, I've modified the `Dialog` constructor to allow for a template option to passed -- if specified, it `domify`s that parameter instead of using the local template that is provided with the component.

If the PR is approved by the maintainers, I will go back and add documentation on how to use this feature.

Thanks!
