### PR TITLE
Fix overlay issue #21

### DIFF
--- a/index.js
+++ b/index.js
@@ -234,8 +234,7 @@ Dialog.prototype.show = function(){
   // overlay
   if (overlay) {
     overlay.show();
-    overlay.on('hide', function _hide () {
-      overlay.off('hide', _hide);
+    overlay.once('hide', function () {
       self.hide();
     });
     this._classes.add('modal');

--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ Dialog.prototype.effect = function(type){
  */
 
 Dialog.prototype.modal = function(){
-  this._overlay = overlay();
+  if (!this._overlay) this._overlay = overlay();
   return this;
 };
 
@@ -184,12 +184,7 @@ Dialog.prototype.modal = function(){
 Dialog.prototype.overlay = function(opts){
   var self = this;
   opts = opts || { closable: true };
-  var o = overlay(opts);
-  o.on('hide', function(){
-    self._overlay = null;
-    self.hide();
-  });
-  this._overlay = o;
+  this._overlay = overlay(opts);
   return this;
 };
 
@@ -239,6 +234,10 @@ Dialog.prototype.show = function(){
   // overlay
   if (overlay) {
     overlay.show();
+    overlay.on('hide', function _hide () {
+      overlay.off('hide', _hide);
+      self.hide();
+    });
     this._classes.add('modal');
   }
 
@@ -260,8 +259,7 @@ Dialog.prototype.show = function(){
 
 Dialog.prototype.hideOverlay = function(){
   if (!this._overlay) return;
-  this._overlay.remove();
-  this._overlay = null;
+  this._overlay.hide();
 };
 
 /**
@@ -308,6 +306,8 @@ Dialog.prototype.hide = function(ms){
 
   return self;
 };
+
+
 /**
  * Hide the dialog without potential animation.
  *

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "type": "git",
     "url": "git@github.com:component/dialog.git"
   },
+  "scripts": {
+    "build": "browserify -r ./index.js:dialog -d > build/build.js"
+  },
   "license": "MIT",
   "browser": {
     "emitter": "component-emitter",
@@ -32,9 +35,12 @@
     "component-event": "^0.1.0",
     "component-emitter": "^1.1.1",
     "domify": "^1.1.1",
-    "overlay-component": "^0.3.0",
+    "overlay-component": "^0.3.5",
     "component-classes": "^1.1.3",
     "stringify": "^3.1.0"
   },
-  "style": "./dialog.css"
+  "style": "./dialog.css",
+  "devDependencies": {
+    "browserify": "^10.2.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,5 @@
     "component-classes": "^1.1.3",
     "stringify": "^3.1.0"
   },
-  "style": "./dialog.css",
-  "devDependencies": {
-    "browserify": "^10.2.3"
-  }
+  "style": "./dialog.css"
 }

--- a/test/index.html
+++ b/test/index.html
@@ -63,11 +63,11 @@
             .on('hide', function(){
               console.log('closed fourth');
 
-              dialog('Click the overlay to close')
+              var overlayDialog = dialog('Click the overlay to close')
               .effect('slide')
               .overlay()
               .show()
-              .on('hide', function(){
+              .once('hide', function(){
                 console.log('closed fifth');
 
                 dialog('Modal')
@@ -93,6 +93,9 @@
                     .show()
                     .on('hide', function(){
                       console.log('closed eight');
+
+                      //test overlay once again (#21)
+                      overlayDialog.show();
                     });
 
                   });


### PR DESCRIPTION
A solution for #21.
`this._overlay` reference is kept untouched, supposing that once overlay is created it sticks to the dialog.
